### PR TITLE
Fix dart parser helper: _token is only ever passed a String

### DIFF
--- a/lib/src/dart/grammar.dart
+++ b/lib/src/dart/grammar.dart
@@ -31,9 +31,9 @@ class DartGrammar extends CompositeParser2 {
   }
 
   /** Defines a token parser that consumes whitespace. */
-  Parser _token(dynamic input) {
-    var parser = input is Parser ? input :
-        input.length == 1 ? char(input) :
+  Parser _token(String input) {
+    assert(input != null && input.length > 0);
+    var parser = input.length == 1 ? char(input) :
         string(input);
     return parser.token().trim(ref('whitespace'));
   }


### PR DESCRIPTION
So make it just take a String

There was a bug w/ the ? using the undefined parser value (see first commit) but it seems that taking a token in is not needed. So just a String?
