### PR TITLE
Add a parser extension to provide custom methods for Parser

### DIFF
--- a/lib/petitparser.dart
+++ b/lib/petitparser.dart
@@ -158,6 +158,7 @@ library petitparser;
 
 import 'package:meta/meta.dart';
 import 'dart:collection';
+import 'dart:mirrors';
 
 part 'src/core/actions.dart';
 part 'src/core/characters.dart';

--- a/lib/src/core/parser.dart
+++ b/lib/src/core/parser.dart
@@ -398,4 +398,16 @@ abstract class Parser {
     // no children, nothing to do
   }
 
+  noSuchMethod(Invocation msg) {
+      if (parserExtension != null) {
+          InstanceMirror im = reflect(parserExtension);
+          var params = [this];
+          params.addAll(msg.positionalArguments);
+          return im.invoke(msg.memberName, params).reflectee;
+      }
+      super.noSuchMethod(msg);
+  }
+
 }
+
+var parserExtension = null;

--- a/test/parser_extension_test.dart
+++ b/test/parser_extension_test.dart
@@ -1,0 +1,26 @@
+library parser_extension_test;
+
+import 'package:petitparser/petitparser.dart';
+import 'package:unittest/unittest.dart';
+
+class _MyExtension {
+    until(Parser self, Parser newParser) => self.seq(newParser.neg().star()).seq(newParser);
+}
+
+void _initParserExtension() {
+    parserExtension = new _MyExtension();
+}
+
+void main() {
+
+    _initParserExtension();
+
+    test("custom methods", () {
+        var parser = string("/*").until(string("*/")).flatten();
+        var result = parser.parse("/* hello, /* extension */");
+        expect(result.isSuccess, true);
+        expect(result.value, "/* hello, /* extension */");
+        expect(result.position, 25);
+    });
+
+}


### PR DESCRIPTION
I defined a `noSuchMethod` in `Parser`, and it will check a `parserExtension` object for missing methods.

The `parserExtension` object can be set in client code, and user can define a class with some extension methods.

There is a test file in the commit, and you can get my idea.

I haven't written the doc, and I hope to get your advice on the idea. Thank you!
