### PR TITLE
Non breaking changes

### DIFF
--- a/lib/src/core/actions.dart
+++ b/lib/src/core/actions.dart
@@ -23,8 +23,9 @@ class ActionParser extends DelegateParser {
   Parser copy() => new ActionParser(_delegate, _function);
 
   @override
-  bool hasEqualProperties(ActionParser other) {
-    return super.hasEqualProperties(other) && _function == other._function;
+  bool hasEqualProperties(Parser other) {
+    return other is ActionParser && super.hasEqualProperties(other)
+        && _function == other._function;
   }
 }
 

--- a/lib/src/core/characters.dart
+++ b/lib/src/core/characters.dart
@@ -28,8 +28,9 @@ class CharacterParser extends Parser {
   Parser copy() => new CharacterParser(_predicate, _message);
 
   @override
-  bool hasEqualProperties(CharacterParser other) {
-    return super.hasEqualProperties(other) &&
+  bool hasEqualProperties(Parser other) {
+    return other is CharacterParser &&
+        super.hasEqualProperties(other) &&
         _predicate == other._predicate &&
         _message == other._message;
   }

--- a/lib/src/core/combinators.dart
+++ b/lib/src/core/combinators.dart
@@ -53,8 +53,9 @@ class EndOfInputParser extends DelegateParser {
   Parser copy() => new EndOfInputParser(_delegate, _message);
 
   @override
-  bool hasEqualProperties(EndOfInputParser other) {
-    return super.hasEqualProperties(other) && _message == other._message;
+  bool hasEqualProperties(Parser other) {
+    return other is EndOfInputParser && super.hasEqualProperties(other)
+        && _message == other._message;
   }
 }
 
@@ -105,8 +106,9 @@ class NotParser extends DelegateParser {
   Parser copy() => new NotParser(_delegate, _message);
 
   @override
-  bool hasEqualProperties(NotParser other) {
-    return super.hasEqualProperties(other) && _message == other._message;
+  bool hasEqualProperties(Parser other) {
+    return other is NotParser && super.hasEqualProperties(other)
+        && _message == other._message;
   }
 }
 
@@ -132,8 +134,9 @@ class OptionalParser extends DelegateParser {
   Parser copy() => new OptionalParser(_delegate, _otherwise);
 
   @override
-  bool hasEqualProperties(OptionalParser other) {
-    return super.hasEqualProperties(other) && _otherwise == other._otherwise;
+  bool hasEqualProperties(Parser other) {
+    return other is OptionalParser && super.hasEqualProperties(other)
+        && _otherwise == other._otherwise;
   }
 }
 

--- a/lib/src/core/parsers.dart
+++ b/lib/src/core/parsers.dart
@@ -23,8 +23,9 @@ class EpsilonParser extends Parser {
   Parser copy() => new EpsilonParser(_result);
 
   @override
-  bool hasEqualProperties(EpsilonParser other) {
-    return super.hasEqualProperties(other) && _result == other._result;
+  bool hasEqualProperties(Parser other) {
+    return other is EpsilonParser && super.hasEqualProperties(other)
+        && _result == other._result;
   }
 }
 
@@ -55,8 +56,10 @@ class FailureParser extends Parser {
   Parser copy() => new FailureParser(_message);
 
   @override
-  bool hasEqualProperties(FailureParser other) {
-    return super.hasEqualProperties(other) && _message == other._message;
+  bool hasEqualProperties(Parser other) {
+    return other is FailureParser
+        && super.hasEqualProperties(other)
+        && _message == other._message;
   }
 }
 

--- a/lib/src/core/predicates.dart
+++ b/lib/src/core/predicates.dart
@@ -31,8 +31,10 @@ class AnyParser extends Parser {
   Parser copy() => new AnyParser(_message);
 
   @override
-  bool hasEqualProperties(AnyParser other) {
-    return super.hasEqualProperties(other) && _message == other._message;
+  bool hasEqualProperties(Parser other) {
+    return other is AnyParser &&
+        super.hasEqualProperties(other) &&
+        _message == other._message;
   }
 }
 
@@ -117,8 +119,9 @@ class PredicateParser extends Parser {
   Parser copy() => new PredicateParser(_length, _predicate, _message);
 
   @override
-  bool hasEqualProperties(PredicateParser other) {
-    return super.hasEqualProperties(other) &&
+  bool hasEqualProperties(Parser other) {
+    return other is PredicateParser &&
+        super.hasEqualProperties(other) &&
         _length == other._length &&
         _predicate == other._predicate &&
         _message == other._message;

--- a/lib/src/core/repeaters.dart
+++ b/lib/src/core/repeaters.dart
@@ -25,8 +25,9 @@ abstract class RepeatingParser extends DelegateParser {
   }
 
   @override
-  bool hasEqualProperties(RepeatingParser other) {
-    return super.hasEqualProperties(other) &&
+  bool hasEqualProperties(Parser other) {
+    return other is RepeatingParser &&
+        super.hasEqualProperties(other) &&
         _min == other._min &&
         _max == other._max;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: petitparser
-version: 1.3.4
+version: 1.3.5
 author: Lukas Renggli <renggli@gmail.com>
 description: Dynamic parser combinator framework.
 homepage: https://github.com/renggli/dart-petitparser


### PR DESCRIPTION
Change hasEqualProperties to gracefully handle parsers of inconsistent types.
False is returned if the parsers are not of the same type matching general Dart equality semantics and keeping the signatures of all methods that implement hasEqualProperties consistent.