### PR TITLE
Rename local variable

### DIFF
--- a/lib/src/reflection/transform.dart
+++ b/lib/src/reflection/transform.dart
@@ -15,8 +15,8 @@ typedef Parser TransformationHandler(Parser parser);
  */
 Parser transformParser(Parser parser, TransformationHandler handler) {
   var mapping = new Map.identity();
-  for (var parser in allParser(parser)) {
-    mapping[parser] = handler(parser.copy());
+  for (var each in allParser(parser)) {
+    mapping[each] = handler(each.copy());
   }
   var seen = new Set.from(mapping.values);
   var todo = new List.from(mapping.values);


### PR DESCRIPTION
Two variables with the same name in the same scope? Ouch!

I know you can get away with this in Dart, but... this just cost me half a day of debugging and tracing through the code, and was the cause of a major bug in my PHP port, where the argument `parser` was being overwritten by the variable `parser` ... ouch! ;-)

Maybe pass this on to the Dart IDE team? It really would make sense to get a warning in the IDE when doing this. I'm pretty sure you didn't do that deliberately? And it's probably not considered good practice? There are benefits to locally scoped variables, but ambiguous symbols is not one of them ;-)