### PR TITLE
Fixed a Dart 2.0 strong mode error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.1
+
+* Fixed Dart 2.0 strong mode error (parseOn method in
+  'core/repeaters/possesive.dart' is not returning the correct Iterable)
+
 ## 1.7.0
 
 * Dart 2.0 compatibility.

--- a/lib/src/core/characters/optimize.dart
+++ b/lib/src/core/characters/optimize.dart
@@ -9,7 +9,7 @@ CharacterPredicate optimizedString(String string) {
   return optimizedRanges(string.codeUnits.map((value) => new RangeCharPredicate(value, value)));
 }
 
-CharacterPredicate optimizedRanges(Iterable<RangeCharPredicate> ranges) {
+CharacterPredicate optimizedRanges(Iterable ranges) {
   // 1. sort the ranges
   List<RangeCharPredicate> sortedRanges = new List.from(ranges, growable: false);
   sortedRanges.sort((first, second) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: petitparser
-version: 1.7.0
+version: 1.7.1
 author: Lukas Renggli <renggli@gmail.com>
 description: Dynamic parser combinator framework.
 homepage: https://github.com/petitparser/dart-petitparser


### PR DESCRIPTION
Fixed a Dart 2.0 strong mode error (parseOn method
'core/repeaters/possesive.dart' is not returning the correct Iterable)