### PR TITLE
Lower the SDK constraint for Flutter beta compatibility

### DIFF
--- a/petitparser/pubspec.yaml
+++ b/petitparser/pubspec.yaml
@@ -6,7 +6,7 @@ description: A dynamic parser framework to build efficient grammars and parsers
   quickly.
 
 environment:
-  sdk: '>=2.12.0-259.14.beta <3.0.0'
+  sdk: '>=2.12.0-259.12.beta <3.0.0'
 dependencies:
   meta: ^1.3.0
 dev_dependencies:


### PR DESCRIPTION
Trying to use petitparser with Flutter beta results to:

    Resolving dependencies...
    The current Dart SDK version is 2.12.0-259.12.beta.

    Because petitparser requires SDK version >=2.12.0-259.14.beta <3.0.0, version solving failed.

Because the latest Flutter beta has Dart SDK 2.12.0-259.12.beta:

    Flutter 1.26.0-17.6.pre • channel beta • https://github.com/flutter/flutter.git
    Framework • revision a29104a69b (3 days ago) • 2021-02-16 09:26:56 -0800
    Engine • revision 21fa8bb99e
    Tools • Dart 2.12.0 (build 2.12.0-259.12.beta)