### PR TITLE
Fix behavior of quote in lisp in petitparser_examples.

### DIFF
--- a/petitparser_examples/lib/src/lisp/evaluator.dart
+++ b/petitparser_examples/lib/src/lisp/evaluator.dart
@@ -1,12 +1,15 @@
 import 'package:petitparser/petitparser.dart';
 
+import 'quote.dart';
 import 'cons.dart';
 import 'environment.dart';
 import 'name.dart';
 
 /// The evaluation function.
 dynamic eval(Environment env, dynamic expr) {
-  if (expr is Cons) {
+  if (expr is Quote) {
+    return expr.datum;
+  } else if (expr is Cons) {
     final Function function = eval(env, expr.head);
     return function(env, expr.tail);
   } else if (expr is Name) {

--- a/petitparser_examples/lib/src/lisp/evaluator.dart
+++ b/petitparser_examples/lib/src/lisp/evaluator.dart
@@ -1,9 +1,9 @@
 import 'package:petitparser/petitparser.dart';
 
-import 'quote.dart';
 import 'cons.dart';
 import 'environment.dart';
 import 'name.dart';
+import 'quote.dart';
 
 /// The evaluation function.
 dynamic eval(Environment env, dynamic expr) {

--- a/petitparser_examples/lib/src/lisp/grammar.dart
+++ b/petitparser_examples/lib/src/lisp/grammar.dart
@@ -40,7 +40,7 @@ class LispGrammarDefinition extends GrammarDefinition {
       pattern('a-zA-Z!#\$%&*/:<=>?@\\^_|~+-') &
       pattern('a-zA-Z0-9!#\$%&*/:<=>?@\\^_|~+-').star();
 
-  Parser quote() => char('\'') & ref0(list);
+  Parser quote() => char('\'') & ref0(atom);
   Parser quasiquote() => char('`') & ref0(list);
   Parser unquote() => char(',') & ref0(list);
   Parser splice() => char('@') & ref0(list);

--- a/petitparser_examples/lib/src/lisp/native.dart
+++ b/petitparser_examples/lib/src/lisp/native.dart
@@ -73,7 +73,7 @@ class NativeEnvironment extends Environment {
   }
 
   static dynamic _quote(Environment env, dynamic args) {
-    return args;
+    return args.head;
   }
 
   static dynamic _eval(Environment env, dynamic args) {

--- a/petitparser_examples/lib/src/lisp/parser.dart
+++ b/petitparser_examples/lib/src/lisp/parser.dart
@@ -1,5 +1,6 @@
 import 'package:petitparser/petitparser.dart';
 
+import 'quote.dart';
 import 'cons.dart';
 import 'grammar.dart';
 import 'name.dart';
@@ -28,5 +29,5 @@ class LispParserDefinition extends LispGrammarDefinition {
   Parser number() => super.number().map((each) => num.parse(each));
 
   Parser quote() =>
-      super.quote().map((each) => Cons((_, args) => args, each[1]));
+  super.quote().map((each) => Quote(each[1]));
 }

--- a/petitparser_examples/lib/src/lisp/parser.dart
+++ b/petitparser_examples/lib/src/lisp/parser.dart
@@ -1,9 +1,9 @@
 import 'package:petitparser/petitparser.dart';
 
-import 'quote.dart';
 import 'cons.dart';
 import 'grammar.dart';
 import 'name.dart';
+import 'quote.dart';
 
 /// The standard lisp parser definition.
 final _definition = LispParserDefinition();

--- a/petitparser_examples/lib/src/lisp/quote.dart
+++ b/petitparser_examples/lib/src/lisp/quote.dart
@@ -1,8 +1,10 @@
+import 'package:petitparser/petitparser.dart';
+
 /// A quoted datum
 ///
 class Quote {
   /// The quoted datum.
-  final datum;
+  final Parser datum;
   
   /// Constructs as a quote.
   Quote(this.datum);

--- a/petitparser_examples/lib/src/lisp/quote.dart
+++ b/petitparser_examples/lib/src/lisp/quote.dart
@@ -1,10 +1,8 @@
-import 'package:petitparser/petitparser.dart';
-
 /// A quoted datum
 ///
 class Quote {
   /// The quoted datum.
-  final Parser datum;
+  Object? datum;
   
   /// Constructs as a quote.
   Quote(this.datum);

--- a/petitparser_examples/lib/src/lisp/quote.dart
+++ b/petitparser_examples/lib/src/lisp/quote.dart
@@ -1,0 +1,9 @@
+/// A quoted datum
+///
+class Quote {
+  /// The quoted datum.
+  final datum;
+  
+  /// Constructs as a quote.
+  Quote(this.datum);
+}

--- a/petitparser_examples/test/lisp_test.dart
+++ b/petitparser_examples/test/lisp_test.dart
@@ -277,17 +277,18 @@ void main() {
       expect(exec('((lambda (x y z) (+ x y z)) 2 4 6)'), 12);
     });
     test('Quote', () {
-      expect(exec('(quote)'), null);
-      expect(exec('(quote 1)'), Cons(1, null));
-      expect(exec('(quote + 1)'), Cons(Name('+'), Cons(1, null)));
+      expect(exec('(quote 1)'), 1);
+      expect(exec('(quote a)'), Name('a'));
+      expect(exec('(quote (+ 1))'), Cons(Name('+'), Cons(1, null)));
     });
     test('Quote (syntax)', () {
       expect(exec('\'()'), null);
+      expect(exec('\'a'), Name('a'));
       expect(exec('\'(1)'), Cons(1, null));
       expect(exec('\'(+ 1)'), Cons(Name('+'), Cons(1, null)));
     });
     test('Eval', () {
-      expect(exec('(eval (quote + 1 2))'), 3);
+      expect(exec('(eval (quote (+ 1 2)))'), 3);
     });
     test('Apply', () {
       expect(exec('(apply + 1 2 3)'), 6);


### PR DESCRIPTION
This PR fixes behavior of quote in the lisp example such that:

'a -> a
(quote a) -> a

(Behavior of quasiquote et al is still incomplete.)
