### PR TITLE
Fix isEqualTo in not.dart

### DIFF
--- a/lib/src/parser/character/not.dart
+++ b/lib/src/parser/character/not.dart
@@ -12,5 +12,5 @@ class NotCharacterPredicate extends CharacterPredicate {
   @override
   bool isEqualTo(CharacterPredicate other) =>
       other is NotCharacterPredicate &&
-      other.predicate.isEqualTo(other.predicate);
+      predicate.isEqualTo(other.predicate);
 }


### PR DESCRIPTION
other.predicate is checking against itself rather than this.predicate.