### PR TITLE
Make the loopback variable public in expression builder

### DIFF
--- a/lib/src/expression/builder.dart
+++ b/lib/src/expression/builder.dart
@@ -69,7 +69,11 @@ import 'utils.dart';
 class ExpressionBuilder<T> {
   final List<Parser<T>> _primitives = [];
   final List<ExpressionGroup<T>> _groups = [];
-  final SettableParser<T> loopback = undefined();
+  final SettableParser<T> _loopback = undefined();
+
+  /// The parser for this expression builder. Can be used to loop back to this
+  /// parser.
+  SettableParser<T> loopback => _loopback;
 
   /// Defines a new primitive, literal, or value [parser].
   void primitive(Parser<T> parser) => _primitives.add(parser);

--- a/lib/src/expression/builder.dart
+++ b/lib/src/expression/builder.dart
@@ -73,7 +73,7 @@ class ExpressionBuilder<T> {
 
   /// The parser for this expression builder. Can be used to loop back to this
   /// parser.
-  SettableParser<T> loopback => _loopback;
+  SettableParser<T> get loopback => _loopback;
 
   /// Defines a new primitive, literal, or value [parser].
   void primitive(Parser<T> parser) => _primitives.add(parser);

--- a/lib/src/expression/builder.dart
+++ b/lib/src/expression/builder.dart
@@ -69,7 +69,7 @@ import 'utils.dart';
 class ExpressionBuilder<T> {
   final List<Parser<T>> _primitives = [];
   final List<ExpressionGroup<T>> _groups = [];
-  final SettableParser<T> _loopback = undefined();
+  final SettableParser<T> loopback = undefined();
 
   /// Defines a new primitive, literal, or value [parser].
   void primitive(Parser<T> parser) => _primitives.add(parser);
@@ -77,7 +77,7 @@ class ExpressionBuilder<T> {
   /// Creates a new group of operators that share the same priority.
   @useResult
   ExpressionGroup<T> group() {
-    final group = ExpressionGroup<T>(_loopback);
+    final group = ExpressionGroup<T>(loopback);
     _groups.add(group);
     return group;
   }
@@ -94,15 +94,15 @@ class ExpressionBuilder<T> {
       buildChoice(primitives),
       (parser, group) => group.build(parser),
     );
-    // Replace all uses of `_loopback` with `parser`. Do not use `resolve()`
+    // Replace all uses of `loopback` with `parser`. Do not use `resolve()`
     // because that might try to resolve unrelated parsers outside of the scope
     // of the `ExpressionBuilder` and cause infinite recursion.
     for (final parent in allParser(parser)) {
-      parent.replace(_loopback, parser);
+      parent.replace(loopback, parser);
     }
     // Also update the loopback parser, just in case somebody keeps a reference
     // to it (not that anybody should do that).
-    _loopback.set(parser);
+    loopback.set(parser);
     return parser;
   }
 }


### PR DESCRIPTION
This is useful for complex parsers where you want the nice stuff from expression builder but don't want to loose the ability to loop back from you expression builder. For example, in my parser I have something like this:

```dart
  final builder = ExpressionBuilder<Token<Expr>>();

  final expr = builder.loopback;
```

`expr` gets used in the `lines` parser, which gets used in the `block` parser. The `block` parser is a primitive for the expression builder again.