### PR TITLE
Relax meta version for Flutter compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ topics:
 environment:
   sdk: ^3.8.0
 dependencies:
-  meta: ^1.17.0
+  meta: ^1.16.0
   collection: ^1.19.0
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
Flutter 3.35 (just released to stable channel today) has `meta` [pinned](https://github.com/dart-lang/sdk/blob/main/docs/Flutter-Pinned-Packages.md) to 1.16.0, so for petitparser 7.0 to be used with Flutter projects this constraint must be relaxed.

I did check that the tests pass with both 1.16.0 and 1.17.0.

